### PR TITLE
Move timer hook code to the actual timer update

### DIFF
--- a/nvtf/NVTF.vcxproj
+++ b/nvtf/NVTF.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="internal\FastExit.cpp" />
     <ClCompile Include="internal\Game\Bethesda\BGSSaveLoadGame.cpp" />
     <ClCompile Include="internal\Game\Bethesda\bhkWorld.cpp" />
+    <ClCompile Include="internal\Game\Bethesda\BSTimer.cpp" />
     <ClCompile Include="internal\Game\Bethesda\Interface.cpp" />
     <ClCompile Include="internal\Game\Bethesda\StartMenu.cpp" />
     <ClCompile Include="internal\Game\Bethesda\TESMain.cpp" />
@@ -232,6 +233,7 @@
     <ClInclude Include="internal\FastExit.hpp" />
     <ClInclude Include="internal\Game\Bethesda\BGSSaveLoadGame.hpp" />
     <ClInclude Include="internal\Game\Bethesda\bhkWorld.hpp" />
+    <ClInclude Include="internal\Game\Bethesda\BSTimer.hpp" />
     <ClInclude Include="internal\Game\Bethesda\Interface.hpp" />
     <ClInclude Include="internal\Game\Bethesda\StartMenu.hpp" />
     <ClInclude Include="internal\Game\Bethesda\TESMain.hpp" />

--- a/nvtf/NVTF.vcxproj.filters
+++ b/nvtf/NVTF.vcxproj.filters
@@ -55,6 +55,9 @@
     <ClCompile Include="internal\Game\Bethesda\TESMain.cpp">
       <Filter>internal\Game\Bethesda</Filter>
     </ClCompile>
+    <ClCompile Include="internal\Game\Bethesda\BSTimer.cpp">
+      <Filter>internal\Game\Bethesda</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="internal\ThreadingTweaks.hpp">
@@ -100,6 +103,9 @@
       <Filter>internal\Game\Bethesda</Filter>
     </ClInclude>
     <ClInclude Include="internal\Game\Bethesda\TESMain.hpp">
+      <Filter>internal\Game\Bethesda</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\Game\Bethesda\BSTimer.hpp">
       <Filter>internal\Game\Bethesda</Filter>
     </ClInclude>
   </ItemGroup>

--- a/nvtf/internal/Game/Bethesda/BSTimer.cpp
+++ b/nvtf/internal/Game/Bethesda/BSTimer.cpp
@@ -1,0 +1,6 @@
+#include "BSTimer.hpp"
+
+// GAME - 0xAA4EE0
+void BSTimer::Update(uint32_t auiTime) {
+	ThisCall(0xAA4EE0, this, auiTime);
+}

--- a/nvtf/internal/Game/Bethesda/BSTimer.hpp
+++ b/nvtf/internal/Game/Bethesda/BSTimer.hpp
@@ -2,14 +2,17 @@
 
 class BSTimer {
 public:
-	bool		bDisableCounter;
+	uint8_t		ucDisableCounter;
 	float		fClamp;
 	float		fClampRemainder;
 	float		fDelta;
 	float		fRealTimeDelta;
-	uint32_t	uiMsPassed;
-	uint32_t	uiUnk18;
+	uint32_t	uiLastTime;
+	uint32_t	uiFirstTime;
 	bool		bIsChangeTimeMultSlowly;
+	bool		bSameFrameDelta;
+
+	void Update(uint32_t auiTime);
 };
 
 ASSERT_SIZE(BSTimer, 0x20);


### PR DESCRIPTION
Clamp value is more correct now - it's polled at the timer update call, instead of mainloop start (timer is updated a bit later).