### PR TITLE
Async geometry precache queue

### DIFF
--- a/nvtf/NVTF.vcxproj
+++ b/nvtf/NVTF.vcxproj
@@ -138,6 +138,8 @@
     <ClCompile Include="internal\Game\Bethesda\TESMain.cpp" />
     <ClCompile Include="internal\Game\Bethesda\TimeGlobal.cpp" />
     <ClCompile Include="internal\Game\Gamebryo\NiDX9Renderer.cpp" />
+    <ClCompile Include="internal\Game\Gamebryo\NiRenderer.cpp" />
+    <ClCompile Include="internal\GeometryPrecacheQueue.cpp" />
     <ClCompile Include="internal\INIUtils.cpp" />
     <ClCompile Include="internal\ThreadingTweaks.cpp" />
     <ClCompile Include="internal\D3DHooks.cpp" />
@@ -158,7 +160,12 @@
     <ClInclude Include="internal\Game\Bethesda\StartMenu.hpp" />
     <ClInclude Include="internal\Game\Bethesda\TESMain.hpp" />
     <ClInclude Include="internal\Game\Bethesda\TimeGlobal.hpp" />
+    <ClInclude Include="internal\Game\Gamebryo\NiCriticalSection.hpp" />
     <ClInclude Include="internal\Game\Gamebryo\NiDX9Renderer.hpp" />
+    <ClInclude Include="internal\Game\Gamebryo\NiRefObject.hpp" />
+    <ClInclude Include="internal\Game\Gamebryo\NiRenderer.hpp" />
+    <ClInclude Include="internal\Game\Gamebryo\NiSmartPointer.hpp" />
+    <ClInclude Include="internal\GeometryPrecacheQueue.hpp" />
     <ClInclude Include="internal\INIUtils.hpp" />
     <ClInclude Include="internal\ThreadingTweaks.hpp" />
     <ClInclude Include="internal\D3DHooks.hpp" />

--- a/nvtf/NVTF.vcxproj.filters
+++ b/nvtf/NVTF.vcxproj.filters
@@ -70,6 +70,12 @@
     <ClCompile Include="internal\INIUtils.cpp">
       <Filter>internal</Filter>
     </ClCompile>
+    <ClCompile Include="internal\GeometryPrecacheQueue.cpp">
+      <Filter>internal\Patches</Filter>
+    </ClCompile>
+    <ClCompile Include="internal\Game\Gamebryo\NiRenderer.cpp">
+      <Filter>internal\Game\Gamebryo</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\nvse\nvse_version.h">
@@ -125,6 +131,21 @@
     </ClInclude>
     <ClInclude Include="internal\FastExit.hpp">
       <Filter>internal\Patches</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\GeometryPrecacheQueue.hpp">
+      <Filter>internal\Patches</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\Game\Gamebryo\NiSmartPointer.hpp">
+      <Filter>internal\Game\Gamebryo</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\Game\Gamebryo\NiRenderer.hpp">
+      <Filter>internal\Game\Gamebryo</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\Game\Gamebryo\NiCriticalSection.hpp">
+      <Filter>internal\Game\Gamebryo</Filter>
+    </ClInclude>
+    <ClInclude Include="internal\Game\Gamebryo\NiRefObject.hpp">
+      <Filter>internal\Game\Gamebryo</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/nvtf/internal/Game/Bethesda/TESMain.cpp
+++ b/nvtf/internal/Game/Bethesda/TESMain.cpp
@@ -1,5 +1,9 @@
 #include "TESMain.hpp"
 
+TESMain* TESMain::GetSingleton() {
+	return *reinterpret_cast<TESMain**>(0x11DEA0C);
+}
+
 bool TESMain::IsInPauseFade() {
-    return *(bool*)0x11DEA2D;
+    return *reinterpret_cast<bool*>(0x11DEA2D);
 }

--- a/nvtf/internal/Game/Bethesda/TESMain.hpp
+++ b/nvtf/internal/Game/Bethesda/TESMain.hpp
@@ -2,5 +2,21 @@
 
 class TESMain {
 public:
+	bool					bOneMore;
+	bool					bQuitGame;
+	bool					bResetGame;
+	bool					bGameActive;
+	bool					bOnIdle;
+	bool					unk05;
+	bool					bIsFlyCam;
+	bool					bFreezeTime;
+	HWND					hWnd;
+	HINSTANCE				hInstance;
+	uint32_t				uiMainThreadID;
+	HANDLE					hMainThread;
+	// There's more but we don't need it for now
+
+	static TESMain* GetSingleton();
+
 	static bool IsInPauseFade();
 };

--- a/nvtf/internal/Game/Gamebryo/NiCriticalSection.hpp
+++ b/nvtf/internal/Game/Gamebryo/NiCriticalSection.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+class NiCriticalSection {
+public:
+	NiCriticalSection() {
+		InitializeCriticalSection(&m_kCriticalSection);
+		m_ulThreadOwner = 0;
+		m_uiLockCount = 0;
+	}
+
+	~NiCriticalSection() {
+		DeleteCriticalSection(&m_kCriticalSection);
+	}
+
+	CRITICAL_SECTION	m_kCriticalSection;
+	uint32_t			m_ulThreadOwner;
+	uint32_t			m_uiLockCount;
+
+	void Lock() {
+		EnterCriticalSection(&m_kCriticalSection); 
+	}
+
+	void Unlock() {
+		LeaveCriticalSection(&m_kCriticalSection);
+	}
+
+	bool TryLock() {
+		return TryEnterCriticalSection(&m_kCriticalSection);
+	}
+};
+
+ASSERT_SIZE(NiCriticalSection, 0x20);
+
+struct NiCriticalSectionScope {
+	NiCriticalSectionScope(NiCriticalSection& aCriticalSection) : rCriticalSection(aCriticalSection) {
+		rCriticalSection.Lock();
+	}
+
+	NiCriticalSectionScope(NiCriticalSection* apCriticalSection) : rCriticalSection(*apCriticalSection) {
+		rCriticalSection.Lock();
+	}
+
+	~NiCriticalSectionScope() {
+		rCriticalSection.Unlock();
+	}
+
+	NiCriticalSection& rCriticalSection;
+};

--- a/nvtf/internal/Game/Gamebryo/NiDX9Renderer.cpp
+++ b/nvtf/internal/Game/Gamebryo/NiDX9Renderer.cpp
@@ -1,6 +1,15 @@
 #include "NiDX9Renderer.hpp"
 
+NiDX9Renderer* NiDX9Renderer::GetSingleton() {
+	return *reinterpret_cast<NiDX9Renderer**>(0x11C73B4);
+}
+
 // GAME - 0xE69410
 bool NiDX9Renderer::IsD3D9Create() {
 	return CdeclCall<bool>(0xE69410);
-};
+}
+
+// GAME - 0xE73F60
+bool NiDX9Renderer::PrecacheGeometryEx(NiRefObject* apGeometry, uint32_t uiBonesPerPartition, uint32_t uiBonesPerVertex, NiD3DShaderDeclaration* apShaderDeclaration) {
+	return ThisCall<bool>(0xE73F60, this, apGeometry, uiBonesPerPartition, uiBonesPerVertex, apShaderDeclaration);
+}

--- a/nvtf/internal/Game/Gamebryo/NiDX9Renderer.hpp
+++ b/nvtf/internal/Game/Gamebryo/NiDX9Renderer.hpp
@@ -1,6 +1,20 @@
 #pragma once
 
-class NiDX9Renderer {
+#include "NiRenderer.hpp"
+
+class NiRefObject;
+class NiD3DShaderDeclaration;
+
+class NiDX9Renderer : public NiRenderer {
 public:
+	char pad[0x39C];
+	uint32_t uiPrePackObjectCount;
+
+	static NiDX9Renderer* GetSingleton();
+
 	static bool IsD3D9Create();
+
+	bool PrecacheGeometryEx(NiRefObject* apGeometry, uint32_t uiBonesPerPartition, uint32_t uiBonesPerVertex, NiD3DShaderDeclaration* apShaderDeclaration); // Unvirtualized
 };
+
+ASSERT_OFFSET(NiDX9Renderer, uiPrePackObjectCount, 0x61C);

--- a/nvtf/internal/Game/Gamebryo/NiRefObject.hpp
+++ b/nvtf/internal/Game/Gamebryo/NiRefObject.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "NiSmartPointer.hpp"
+
+NiSmartPointer(NiRefObject);
+
+class NiRefObject {
+public:
+	NiRefObject();
+
+	virtual			~NiRefObject(); // 00 | Destructor
+	virtual void	DeleteThis();   // 01 | Deletes the object
+
+	uint32_t m_uiRefCount;
+
+	// GAME - 0x40F6E0
+	void IncRefCount() {
+		InterlockedIncrement(&m_uiRefCount);
+	}
+
+	// GAME - 0x401970
+	void DecRefCount() {
+		if (!InterlockedDecrement(&m_uiRefCount))
+			DeleteThis();
+	}
+};
+
+ASSERT_SIZE(NiRefObject, 0x8);

--- a/nvtf/internal/Game/Gamebryo/NiRenderer.cpp
+++ b/nvtf/internal/Game/Gamebryo/NiRenderer.cpp
@@ -1,0 +1,15 @@
+#include "NiRenderer.hpp"
+
+// GAME - 0x4A0370
+void NiRenderer::LockRenderer() {
+	m_kRendererLock.Lock();
+}
+
+bool NiRenderer::TryLockRenderer() {
+	return m_kRendererLock.TryLock();
+}
+
+// GAME - 0x4A03C0
+void NiRenderer::UnlockRenderer() {
+	m_kRendererLock.Unlock();
+}

--- a/nvtf/internal/Game/Gamebryo/NiRenderer.hpp
+++ b/nvtf/internal/Game/Gamebryo/NiRenderer.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "NiCriticalSection.hpp"
+
+class NiShader;
+class NiDynamicEffectState;
+class NiRenderedCubeMap;
+class BSShaderAccumulator;
+class NiDX9Renderer;
+class NiPropertyState;
+class NiRenderTargetGroup;
+class NiFrustum;
+
+class NiRenderer {
+public:
+	NiRenderer();
+	virtual ~NiRenderer();
+
+	char							pad[60]; // We don't need everything
+	char							unk040[62];
+	NiCriticalSection				m_kRendererLock;
+	char							unk0A0[94];
+	NiCriticalSection				m_kPrecacheCriticalSection;
+	char							unk120[95];
+	NiCriticalSection				m_kSourceDataCriticalSection;
+	char							unk1AC[92];
+	uint32_t						m_eSavedFrameState;
+	uint32_t						m_eFrameState;
+	uint32_t						m_uiFrameID;
+	bool							m_bRenderTargetGroupActive;
+	bool							m_bBatchRendering;
+	int								unk20C[29];
+
+	void LockRenderer();
+	bool TryLockRenderer();
+	void UnlockRenderer();
+};
+
+ASSERT_SIZE(NiRenderer, 0x280)

--- a/nvtf/internal/Game/Gamebryo/NiSmartPointer.hpp
+++ b/nvtf/internal/Game/Gamebryo/NiSmartPointer.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+template <class T>
+class NiPointer {
+public:
+	__forceinline NiPointer() : m_pObject(nullptr) {};
+	__forceinline NiPointer(T* apObject) : m_pObject(apObject) { if (m_pObject) m_pObject->IncRefCount(); }
+	__forceinline NiPointer(const NiPointer& arPtr) : m_pObject(arPtr.m_pObject) { if (m_pObject) m_pObject->IncRefCount(); }
+	__forceinline ~NiPointer() { if (m_pObject) m_pObject->DecRefCount(); }
+
+	T* m_pObject;
+
+	__forceinline operator T* () const { return m_pObject; }
+	__forceinline T& operator*() const { return *m_pObject; }
+	__forceinline T* operator->() const { return m_pObject; }
+
+	__forceinline NiPointer<T>& operator =(const NiPointer& ptr) {
+		if (m_pObject != ptr.m_pObject) {
+			if (m_pObject)
+				m_pObject->DecRefCount();
+			m_pObject = ptr.m_pObject;
+			if (m_pObject)
+				m_pObject->IncRefCount();
+		}
+		return *this;
+	}
+
+	__forceinline NiPointer<T>& operator =(T* pObject) {
+		if (m_pObject != pObject) {
+			if (m_pObject)
+				m_pObject->DecRefCount();
+			m_pObject = pObject;
+			if (m_pObject)
+				m_pObject->IncRefCount();
+		}
+		return *this;
+	}
+
+	__forceinline bool operator==(T* apObject) const { return (m_pObject == apObject); }
+
+	__forceinline bool operator==(const NiPointer& ptr) const { return (m_pObject == ptr.m_pObject); }
+
+	__forceinline operator bool() const { return m_pObject != nullptr; }
+};
+
+#define NiSmartPointer(className) \
+    class className; \
+    typedef NiPointer<className> className##Ptr;

--- a/nvtf/internal/GeometryPrecacheQueue.cpp
+++ b/nvtf/internal/GeometryPrecacheQueue.cpp
@@ -1,0 +1,126 @@
+#include "GeometryPrecacheQueue.hpp"
+#include "Game/Bethesda/TESMain.hpp"
+#include "Game/Gamebryo/NiDX9Renderer.hpp"
+
+WaitLock				                            GeometryPrecacheQueue::kQueueLock;
+std::queue<GeometryPrecacheQueue::QueuedObject>     GeometryPrecacheQueue::kQueue;
+HANDLE 												GeometryPrecacheQueue::hThread;
+HANDLE												GeometryPrecacheQueue::hTaskEvent;
+HANDLE												GeometryPrecacheQueue::hPauseEvent;
+
+void GeometryPrecacheQueue::InitHooks() {
+	if (!InitializeThread())
+		return;
+
+    ReplaceVirtualFuncEx(0x10EE5A8, &PrecacheGeometry_MT);
+	WriteRelJumpEx(0xE74120, &PerformPrecache_MT);
+
+	WriteRelJumpEx(0x4A0370, &StopProcessing);
+	WriteRelJumpEx(0x4A03C0, &StartProcessing);
+}
+
+bool GeometryPrecacheQueue::PrecacheGeometry_MT(NiRefObject* apGeometry, uint32_t auiBonesPerPartition, uint32_t auiBonesPerVertex, NiD3DShaderDeclaration* apShaderDeclaration) {
+	if (GetCurrentThreadId() == TESMain::GetSingleton()->uiMainThreadID) [[unlikely]] {
+		return PrecacheGeometryEx(apGeometry, auiBonesPerPartition, auiBonesPerVertex, apShaderDeclaration);
+	}
+
+	kQueueLock.Lock();
+	kQueue.push({ apGeometry, auiBonesPerPartition, auiBonesPerVertex, apShaderDeclaration });
+	kQueueLock.Unlock();
+
+	SetEvent(hTaskEvent);
+	return true;
+}
+
+__declspec(naked) void __fastcall PerformPrecache_ST(NiDX9Renderer* apThis) {
+	__asm {
+		sub esp, 0x24
+		push ebx
+		push ebp
+		push 0xE74125
+		retn
+	}
+}
+
+void GeometryPrecacheQueue::PerformPrecache_MT() {
+	if (GetCurrentThreadId() != TESMain::GetSingleton()->uiMainThreadID) [[unlikely]] {
+		SetEvent(hTaskEvent);
+	}
+	else [[likely]] {
+		bool bLocked = TryLockRenderer();
+
+		if (bLocked) {
+			// We got in!
+			PerformPrecache_ST(this);
+			UnlockRenderer();
+		}
+	}
+}
+
+// Runs after the frame has been rendered - this is where we can do our precaching
+void GeometryPrecacheQueue::StartProcessing() {
+	UnlockRenderer();
+	SetEvent(hPauseEvent);
+}
+
+// Runs before the frame is rendered - we cannot do precaching while the frame is being rendered
+void GeometryPrecacheQueue::StopProcessing() {
+	ResetEvent(hPauseEvent);
+	LockRenderer();
+}
+
+DWORD __stdcall GeometryPrecacheQueue::ThreadProc(LPVOID lpThreadParameter) {
+	while (true) {
+		WaitForSingleObject(hPauseEvent, INFINITE);
+		NiDX9Renderer* pRenderer = NiDX9Renderer::GetSingleton();
+		if (pRenderer) {
+			const uint32_t uiPrecacheCount = pRenderer->uiPrePackObjectCount;
+			bool bIsEmpty = kQueue.empty();
+			if (uiPrecacheCount > 5 || !bIsEmpty)
+				SetEvent(hTaskEvent);
+
+			WaitForSingleObject(hTaskEvent, INFINITE);
+
+			bIsEmpty = kQueue.empty();
+			while (!bIsEmpty && WaitForSingleObject(hPauseEvent, INFINITE) == WAIT_OBJECT_0) {
+				auto& rData = kQueue.front();
+				pRenderer->PrecacheGeometryEx(rData.spGeometry, rData.uiBonesPerPartition, rData.uiBonesPerVertex, rData.pShaderDeclaration);
+
+				kQueueLock.Lock();
+				kQueue.pop();
+				bIsEmpty = kQueue.empty();
+				kQueueLock.Unlock();
+			}
+
+			if (uiPrecacheCount && WaitForSingleObject(hPauseEvent, INFINITE) == WAIT_OBJECT_0)
+				PerformPrecache_ST(pRenderer);
+		}
+	}
+
+	return 0;
+}
+
+bool GeometryPrecacheQueue::InitializeThread() {
+	hTaskEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+	hPauseEvent = CreateEvent(nullptr, TRUE, TRUE, nullptr); 
+
+	hThread = CreateThread(nullptr, 0x10000, ThreadProc, nullptr, 0, nullptr);
+	if (hThread) {
+		wchar_t cThreadName[32];
+		_snwprintf_s(cThreadName, sizeof(cThreadName), L"[NVTF] Geometry Precache Queue");
+		SetThreadDescription(hThread, cThreadName);
+		return true;
+	}
+	else {
+		if (hTaskEvent) {
+			CloseHandle(hTaskEvent);
+			hTaskEvent = nullptr;
+		}
+
+		if (hPauseEvent) {
+			CloseHandle(hPauseEvent);
+			hPauseEvent = nullptr;
+		}
+		return false;
+	}
+}

--- a/nvtf/internal/GeometryPrecacheQueue.hpp
+++ b/nvtf/internal/GeometryPrecacheQueue.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Game/Gamebryo/NiRefObject.hpp"
+#include "Game/Gamebryo/NiDX9Renderer.hpp"
+#include <shared/Utils/WaitLock.hpp>
+#include <queue>
+
+class NiD3DShaderDeclaration;
+class NiNode;
+
+class GeometryPrecacheQueue : public NiDX9Renderer {
+public:
+	static void InitHooks();
+
+	bool PrecacheGeometry_MT(NiRefObject* apGeometry, uint32_t auiBonesPerPartition, uint32_t auiBonesPerVertex, NiD3DShaderDeclaration* apShaderDeclaration);
+	void PerformPrecache_MT();
+
+private:
+	struct QueuedObject {
+		NiPointer<NiRefObject>	spGeometry;
+		uint32_t				uiBonesPerPartition = 0;
+		uint32_t				uiBonesPerVertex	= 0;
+		NiD3DShaderDeclaration* pShaderDeclaration	= nullptr;
+	};
+
+	static HANDLE hTaskEvent;
+	static HANDLE hPauseEvent;
+
+	static WaitLock					 kQueueLock;
+	static std::queue<QueuedObject>  kQueue;
+	static HANDLE 					 hThread;
+
+	void StartProcessing();
+	void StopProcessing();
+
+	static DWORD __stdcall ThreadProc(LPVOID lpThreadParameter);
+	static bool InitializeThread();
+};

--- a/nvtf/internal/ThreadingTweaks.cpp
+++ b/nvtf/internal/ThreadingTweaks.cpp
@@ -1,4 +1,5 @@
 #include "ThreadingTweaks.hpp"
+#include "GeometryPrecacheQueue.hpp"
 
 namespace ThreadingTweaks {
 
@@ -110,10 +111,15 @@ namespace ThreadingTweaks {
 
 	void ReplaceGeometryPrecacheLocks() {
 		// NiDX9Renderer::PerformPrecache
-		if (Setting::ucReplaceGeometryPrecacheLocks) {
+		switch (Setting::ucReplaceGeometryPrecacheLocks) {
+		case 0:
 			SafeWrite16(0xE74126, 0xBE90);
 			SafeWrite32(0xE74128, (uintptr_t)EnterCriticalSectionRendererHook);
-		}
+			break;
+		default: [[likely]]
+			GeometryPrecacheQueue::InitHooks();
+			break;
+		};
 	}
 
 	void TweakMiscCriticalSections() {

--- a/shared/Utils/WaitLock.hpp
+++ b/shared/Utils/WaitLock.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <atomic>
+#include <synchapi.h>
+
+#pragma comment(lib, "Synchronization.lib")
+
+// Lock that uses WaitOnAddress
+class WaitLock {
+private:
+	bool Release() {
+		return ucLock.exchange(OPEN, std::memory_order_acq_rel) == LOCKED;
+	}
+
+public:
+	WaitLock() = default;
+	~WaitLock() = default;
+
+	enum LockState : uint8_t {
+		OPEN	= 0,
+		LOCKED	= 1
+	};
+
+	std::atomic<uint8_t> ucLock = OPEN;
+	
+	bool TryLock() {
+		return ucLock.exchange(LOCKED, std::memory_order_acq_rel) == OPEN;
+	}
+
+	void Lock() {
+		uint8_t ucCmp = LOCKED;
+		while (true) {
+			if (TryLock())
+				break;
+
+			WaitOnAddress(&ucLock, &ucCmp, sizeof(ucLock), INFINITE);
+		}
+	}
+
+	void Unlock() {
+		if (Release())
+			WakeByAddressSingle(&ucLock);
+	}
+};
+
+class WaitLockScope {
+public:
+	WaitLockScope(WaitLock* apLock) : pLock(apLock)	 { pLock->Lock(); };
+	WaitLockScope(WaitLock& arLock) : pLock(&arLock) { pLock->Lock(); };
+	~WaitLockScope() { pLock->Unlock(); };
+
+protected:
+	WaitLock* pLock = nullptr;
+};


### PR DESCRIPTION
Offloads geometry buffers (index, vertex) uploads to a background task thread. This allows the game to render uninterrupted by a background loading thread.

Due to how NiDX9Renderer is set up, and more importantly, how Bethesda implemented it, precache functions share the critical section with the rendered frame - meaning that any time a model gets loaded in the background, either the main thread freezes, or the loading thread does.
To make things worse, rendering at loading happen roughly at the same point in the frame.

Since the loaded geometry is not being rendered in the same frame that it's being loaded, we can safely queue all geometries, and create their buffers in a separate thread, at a different point in time.
Doing so can massively improve overall performance, dramatically reducing loading stutter, especially at high framerates (shorter frames -> more common lock collisions). 