### PR TITLE
Geometry Precache - hold references for the whole precache pass

### DIFF
--- a/nvtf/internal/GeometryPrecacheQueue.hpp
+++ b/nvtf/internal/GeometryPrecacheQueue.hpp
@@ -26,9 +26,10 @@ private:
 	static HANDLE hTaskEvent;
 	static HANDLE hPauseEvent;
 
-	static WaitLock					 kQueueLock;
-	static std::queue<QueuedObject>  kQueue;
-	static HANDLE 					 hThread;
+	static WaitLock								kQueueLock;
+	static std::queue<QueuedObject>				kQueue;
+	static std::vector<NiPointer<NiRefObject>>	kActiveObjects;
+	static HANDLE 								hThread;
 
 	void StartProcessing();
 	void StopProcessing();


### PR DESCRIPTION
Game can delete geometry mid processing, and NiDX9Renderer holds normal pointers.